### PR TITLE
luci: update pkg_version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ THEME_NAME:=4lpha
 THEME_TITLE:=4lpha
 
 PKG_NAME:=luci-theme-$(THEME_NAME)
-PKG_VERSION:=4.1.2-beta1
+PKG_VERSION:=4.1.2_beta1
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk


### PR DESCRIPTION
fixed openwrt build error
```
ERROR: info field 'version' has invalid value: package version is invalid
ERROR: failed to create package: package version is invalid
```